### PR TITLE
fix nfe (=NumberFormatException) when using inner-border on a mj-column

### DIFF
--- a/data/bug-mj-column-inner-border.mjml
+++ b/data/bug-mj-column-inner-border.mjml
@@ -1,0 +1,9 @@
+<mjml>
+    <mj-body>
+        <mj-section>
+            <mj-column padding="25px" border="5px solid green" inner-border="5px solid red" >
+                <mj-text>hello</mj-text>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml>

--- a/src/main/java/ch/digitalfondue/mjml4j/BaseComponent.java
+++ b/src/main/java/ch/digitalfondue/mjml4j/BaseComponent.java
@@ -2,7 +2,11 @@ package ch.digitalfondue.mjml4j;
 
 import org.w3c.dom.Element;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static ch.digitalfondue.mjml4j.Utils.equalsIgnoreCase;
@@ -247,7 +251,7 @@ abstract class BaseComponent {
 
             var paddings = getShorthandAttributeValue("padding", "right") + getShorthandAttributeValue("padding", "left");
 
-            var borders = getShorthandBorderValue("right") + getShorthandBorderValue("left");
+            var borders = getShorthandBorderValue("border", "right") + getShorthandBorderValue("border", "left");
 
 
             if (hasParentComponent() && getParent() instanceof BodyComponent parent) {
@@ -271,9 +275,9 @@ abstract class BaseComponent {
 
         private static final Pattern PATTERN_SHORTHAND_BORDER_VALUE = Pattern.compile("(?:(?:^| )([0-9]+))");
 
-        double getShorthandBorderValue(String direction) {
-            var mjAttributeDirection = getAttribute("border-" + direction);
-            var mjAttribute = getAttribute("border");
+        double getShorthandBorderValue(String attributeName, String direction) {
+            var mjAttributeDirection = getAttribute(attributeName + "-" + direction);
+            var mjAttribute = getAttribute(attributeName);
 
             if (!Utils.isNullOrWhiteSpace(mjAttributeDirection)) {
                 return CssUnitParser.parse(mjAttributeDirection).value();

--- a/src/main/java/ch/digitalfondue/mjml4j/MjmlComponentColumn.java
+++ b/src/main/java/ch/digitalfondue/mjml4j/MjmlComponentColumn.java
@@ -38,8 +38,8 @@ class MjmlComponentColumn extends BaseComponent.BodyComponent {
     CssBoxModel getBoxModel() {
 
         var paddings = getShorthandAttributeValue("padding", "right") + getShorthandAttributeValue("padding", "left");
-        var borders = getShorthandBorderValue("right") + getShorthandBorderValue("left");
-        var innerBorders = getShorthandAttributeValue("inner-border", "left") + getShorthandAttributeValue("inner-border", "right");
+        var borders = getShorthandBorderValue("border", "right") + getShorthandBorderValue("border", "left");
+        var innerBorders = getShorthandBorderValue("inner-border", "left") + getShorthandBorderValue("inner-border", "right");
         var allPaddings = paddings + borders + innerBorders;
 
         if (hasParentComponent()) {

--- a/src/test/java/ch/digitalfondue/mjml4j/BugTests.java
+++ b/src/test/java/ch/digitalfondue/mjml4j/BugTests.java
@@ -5,10 +5,15 @@ import org.junit.jupiter.api.Test;
 import static ch.digitalfondue.mjml4j.Helpers.testTemplate;
 
 class BugTests {
-    
+
     // see https://github.com/digitalfondue/mjml4j/issues/7
     @Test
     void checkMjSocialNpe() {
         testTemplate("bug-mj-social");
+    }
+
+    @Test
+    void checkMjColumnInnerBorderNfe() {
+        testTemplate("bug-mj-column-inner-border");
     }
 }


### PR DESCRIPTION
Fixed an issue when using an "inner-border" on an mj-column. Before the fix, a NumberFormatException was thrown when parsing for example inner-border="5px solid red".

![image](https://github.com/user-attachments/assets/65a8b1f4-bc9c-4ee6-9546-b94bf645ec81)
